### PR TITLE
Add a stub message for prototyping

### DIFF
--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client contains the types and functions used to communicate with other services using
+// queues and topics.
+package client
+
+// Message is an implementation of Message interface
+type Message struct {
+	contentType  string
+	messageBody  string
+	messageCount int
+	messageID    string
+}


### PR DESCRIPTION
**Description**

Add a stub message for prototyping.

In order to start prototyping the moving parts of the client, we need some message place-holder/stub.
This stub is a suggestion and will change as usage stories emerges. 