### PR TITLE
Disconnect instead of close

### DIFF
--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -27,7 +27,7 @@ package client
 type Connection interface {
 	// Connect creates a ne connection to the messaging broker.
 	Connect() error
-	// Close closes the connection, releasing all the resources that it uses. Once closed the
+	// Disconnect closes the connection, releasing all the resources that it uses. Once closed the
 	// connection can't be reused.
-	Close() error
+	Disconnect() error
 }

--- a/pkg/client/stomp_connection.go
+++ b/pkg/client/stomp_connection.go
@@ -90,8 +90,8 @@ func (c *StompConnection) Connect() (err error) {
 	return
 }
 
-// Close closes the connection, releasing all the resources that it uses. Once closed the
+// Disconnect closes the connection, releasing all the resources that it uses. Once closed the
 // connection can't be reused.
-func (c *StompConnection) Close() (err error) {
+func (c *StompConnection) Disconnect() (err error) {
 	return c.connection.Disconnect()
 }


### PR DESCRIPTION
**Description**

While playing with the client `disconnect` sounds better then `close` in our context.


**Motivation**
open -> close vs connect -> disconnect