### PR TITLE
Explicit message

### DIFF
--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -17,8 +17,8 @@ package client
 
 // Message is an implementation of Message interface
 type Message struct {
-	ContentType  string
-	MessageBody  string
-	MessageCount int
-	MessageID    string
+	ContentType string
+	Body        string
+	Count       int
+	ID          string
 }


### PR DESCRIPTION
**Description**

In our message stub, we use explicit struct name in vars. this is ugly :-)
