### PR TITLE
remove unneaded var from message stub struct

### DIFF
--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -19,6 +19,5 @@ package client
 type Message struct {
 	ContentType string
 	Body        string
-	Count       int
 	ID          string
 }


### PR DESCRIPTION
**Description**

The message stub currently have unneeded var `count` we do not have a use case for now.
This PR remove it to make sure it will not find it's way to stable release.

Reference: https://github.com/container-mgmt/messaging-library/pull/9#discussion_r194731104
