### PR TITLE
Move stomp connection implementation to connections dir

### DIFF
--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -30,4 +30,8 @@ type Connection interface {
 	// Close closes the connection, releasing all the resources that it uses. Once closed the
 	// connection can't be reused.
 	Close() error
+
+	// Publish / Subscribe interface
+	Publish(m Message, topic string) error
+	Subscribe(topic string, callback func(m Message, topic string) error) error
 }

--- a/pkg/client/connections/stomp/connection.go
+++ b/pkg/client/connections/stomp/connection.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package stomp
 
 import (
 	"crypto/tls"
@@ -22,21 +22,20 @@ import (
 	"github.com/go-stomp/stomp"
 )
 
-// StompConnection is an implementation of Connection interface
-type StompConnection struct {
+// Connection is an implementation of Connection interface
+type Connection struct {
 	// Global options:
-	BrokerHost      string
-	BrokerPort      int
-	DestinationName string
-	UserName        string
-	UserPassword    string
-	UseTLS          bool
-	InsecureTLS     bool
-	connection      *stomp.Conn
+	BrokerHost   string
+	BrokerPort   int
+	UserName     string
+	UserPassword string
+	UseTLS       bool
+	InsecureTLS  bool
+	connection   *stomp.Conn
 }
 
 // Open creates a new connection to the messaging broker.
-func (c *StompConnection) Open() (err error) {
+func (c *Connection) Open() (err error) {
 	// Calculate the address of the server, as required by the Dial methods:
 	brokerAddress := fmt.Sprintf("%s:%d", c.BrokerHost, c.BrokerPort)
 
@@ -70,7 +69,7 @@ func (c *StompConnection) Open() (err error) {
 	}
 
 	// Prepare the options:
-	options := make([]func(*stomp.Conn) error, 0)
+	var options []func(*stomp.Conn) error
 	if c.UserName != "" {
 		options = append(options, stomp.ConnOpt.Login(c.UserName, c.UserPassword))
 	}
@@ -92,6 +91,6 @@ func (c *StompConnection) Open() (err error) {
 
 // Close closes the connection, releasing all the resources that it uses. Once closed the
 // connection can't be reused.
-func (c *StompConnection) Close() (err error) {
+func (c *Connection) Close() (err error) {
 	return c.connection.Disconnect()
 }

--- a/pkg/client/connections/stomp/publish.go
+++ b/pkg/client/connections/stomp/publish.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stomp
+
+import (
+	"github.com/go-stomp/stomp"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+)
+
+// Publish a message to a topic
+func (c *Connection) Publish(m client.Message, topic string) (err error) {
+	body := []byte(m.Body)
+	contentType := m.ContentType
+
+	err = c.connection.Send(
+		topic,
+		contentType,
+		body,
+		stomp.SendOpt.Header("persistent", "true"),
+	)
+
+	return
+}

--- a/pkg/client/connections/stomp/subscribe.go
+++ b/pkg/client/connections/stomp/subscribe.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stomp
+
+import (
+	"github.com/go-stomp/stomp"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+)
+
+// Subscribe subscribes to a topic
+func (c *Connection) Subscribe(topic string, callback func(m client.Message, topic string) error) (err error) {
+	var subscription *stomp.Subscription
+
+	// Receive messages:
+	subscription, err = c.connection.Subscribe(topic, stomp.AckAuto)
+	if err != nil {
+		// TODO: error
+		return
+	}
+
+	// Wait for messages:
+	for message := range subscription.C {
+		if message.Err != nil {
+			// TODO: error ?
+			break
+		}
+
+		callback(client.Message{Body: string(message.Body)}, topic)
+	}
+
+	return
+}


### PR DESCRIPTION
**Description**

Move stomp connection implementation to connections dir.

**Rational**

STOMP is just an implementation of connection, it is nicer to have it in a directory specially made for connection implementations. 