### PR TITLE
[WIP]Use internal packages

### DIFF
--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/container-mgmt/messaging-library/pkg/client"
-	"github.com/container-mgmt/messaging-library/pkg/client/connections/stomp"
+	"github.com/container-mgmt/messaging-library/pkg/connections/stomp"
 )
 
 var (

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client contains the types and functions used to communicate with other services using
+// queues and topics.
+package client
+
+var connections map[string]Connection
+var connectionName string
+
+// Register a new client connection
+func Register(name string, connection Connection) (err error) {
+	if connections == nil {
+		connections = make(map[string]Connection, 0)
+	}
+
+	// Set last registered connection as default.
+	connectionName = name
+
+	// Add a new connection
+	connections[name] = connection
+
+	return
+}
+
+// Client represent a message broker client
+type Client struct {
+	Name string
+}
+
+// NewConnectionBuilder return a ConnectionBuilder for this connection
+func (c *Client) NewConnectionBuilder() ConnectionBuilder {
+	if c.Name == "" {
+		c.Name = connectionName
+	}
+	return connections[c.Name].NewConnectionBuilder()
+}
+
+// Use specific client by name
+func (c *Client) Use(name string) (err error) {
+	c.Name = name
+
+	return
+}
+
+// Open is
+func (c Client) Open() error {
+	if c.Name == "" {
+		c.Name = connectionName
+	}
+	return connections[c.Name].Open()
+}
+
+// Close is
+func (c Client) Close() error {
+	if c.Name == "" {
+		c.Name = connectionName
+	}
+	return connections[c.Name].Close()
+}
+
+// Publish a message to a topic
+func (c Client) Publish(m Message, topic string) error {
+	if c.Name == "" {
+		c.Name = connectionName
+	}
+	return connections[c.Name].Publish(m, topic)
+}
+
+// Subscribe to a topic
+func (c Client) Subscribe(topic string, callback func(m Message, topic string) error) error {
+	if c.Name == "" {
+		c.Name = connectionName
+	}
+	return connections[c.Name].Subscribe(topic, callback)
+}

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -31,7 +31,12 @@ type Connection interface {
 	// connection can't be reused.
 	Close() error
 
-	// Publish / Subscribe interface
+	// Get a ConnectionBuilder for this connection
+	NewConnectionBuilder() ConnectionBuilder
+
+	// Publish a message to a topic
 	Publish(m Message, topic string) error
+
+	// Subscribe subscribes to a topic
 	Subscribe(topic string, callback func(m Message, topic string) error) error
 }

--- a/pkg/client/connection_builder.go
+++ b/pkg/client/connection_builder.go
@@ -11,25 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package stomp
+package client
 
-import (
-	"github.com/go-stomp/stomp"
-
-	"github.com/container-mgmt/messaging-library/pkg/client"
-)
-
-// Publish a message to a topic
-func (c *Connection) Publish(m client.Message, topic string) (err error) {
-	body := []byte(m.Body)
-	contentType := m.ContentType
-
-	err = c.connection.Send(
-		topic,
-		contentType,
-		body,
-		stomp.SendOpt.Header("persistent", "true"),
-	)
-
-	return
+// ConnectionBuilder is an interface for a connection builder
+type ConnectionBuilder interface {
+	Build() Connection
+	BrokerHost(string) ConnectionBuilder
+	BrokerPort(int) ConnectionBuilder
+	UserName(string) ConnectionBuilder
+	UserPassword(string) ConnectionBuilder
+	UseTLS(bool) ConnectionBuilder
+	InsecureTLS(bool) ConnectionBuilder
 }

--- a/pkg/connections/stomp/connection.go
+++ b/pkg/connections/stomp/connection.go
@@ -20,6 +20,8 @@ import (
 	"net"
 
 	"github.com/go-stomp/stomp"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
 )
 
 // Connection is an implementation of Connection interface
@@ -35,7 +37,7 @@ type Connection struct {
 }
 
 // Open creates a new connection to the messaging broker.
-func (c *Connection) Open() (err error) {
+func (c Connection) Open() (err error) {
 	// Calculate the address of the server, as required by the Dial methods:
 	brokerAddress := fmt.Sprintf("%s:%d", c.BrokerHost, c.BrokerPort)
 
@@ -91,6 +93,11 @@ func (c *Connection) Open() (err error) {
 
 // Close closes the connection, releasing all the resources that it uses. Once closed the
 // connection can't be reused.
-func (c *Connection) Close() (err error) {
+func (c Connection) Close() (err error) {
 	return c.connection.Disconnect()
+}
+
+// NewConnectionBuilder gets a ConnectionBuilder for this connection
+func (c Connection) NewConnectionBuilder() client.ConnectionBuilder {
+	return ConnectionBuilder{}
 }

--- a/pkg/connections/stomp/connection_builder.go
+++ b/pkg/connections/stomp/connection_builder.go
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stomp
+
+import (
+	"github.com/container-mgmt/messaging-library/pkg/client"
+)
+
+// ConnectionBuilder is an implementation of ConnectionBuilder interface
+type ConnectionBuilder struct {
+	connection Connection
+}
+
+// Build setter
+func (c ConnectionBuilder) Build() client.Connection {
+	return c.connection
+}
+
+// BrokerHost setter
+func (c ConnectionBuilder) BrokerHost(h string) client.ConnectionBuilder {
+	c.connection.BrokerHost = h
+
+	return c
+}
+
+// BrokerPort setter
+func (c ConnectionBuilder) BrokerPort(p int) client.ConnectionBuilder {
+	c.connection.BrokerPort = p
+
+	return c
+}
+
+// UserName setter
+func (c ConnectionBuilder) UserName(n string) client.ConnectionBuilder {
+	c.connection.UserName = n
+
+	return c
+}
+
+// UserPassword setter
+func (c ConnectionBuilder) UserPassword(p string) client.ConnectionBuilder {
+	c.connection.UserPassword = p
+
+	return c
+}
+
+// UseTLS setter
+func (c ConnectionBuilder) UseTLS(t bool) client.ConnectionBuilder {
+	c.connection.UseTLS = t
+
+	return c
+}
+
+// InsecureTLS setter
+func (c ConnectionBuilder) InsecureTLS(t bool) client.ConnectionBuilder {
+	c.connection.InsecureTLS = t
+
+	return c
+}

--- a/pkg/connections/stomp/publish.go
+++ b/pkg/connections/stomp/publish.go
@@ -19,26 +19,17 @@ import (
 	"github.com/container-mgmt/messaging-library/pkg/client"
 )
 
-// Subscribe subscribes to a topic
-func (c *Connection) Subscribe(topic string, callback func(m client.Message, topic string) error) (err error) {
-	var subscription *stomp.Subscription
+// Publish a message to a topic
+func (c Connection) Publish(m client.Message, topic string) (err error) {
+	body := []byte(m.Body)
+	contentType := m.ContentType
 
-	// Receive messages:
-	subscription, err = c.connection.Subscribe(topic, stomp.AckAuto)
-	if err != nil {
-		// TODO: error
-		return
-	}
-
-	// Wait for messages:
-	for message := range subscription.C {
-		if message.Err != nil {
-			// TODO: error ?
-			break
-		}
-
-		callback(client.Message{Body: string(message.Body)}, topic)
-	}
+	err = c.connection.Send(
+		topic,
+		contentType,
+		body,
+		stomp.SendOpt.Header("persistent", "true"),
+	)
 
 	return
 }

--- a/pkg/connections/stomp/stomp.go
+++ b/pkg/connections/stomp/stomp.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stomp
+
+import (
+	"github.com/container-mgmt/messaging-library/pkg/client"
+)
+
+func init() {
+	client.Register("STOMP", &Connection{})
+}

--- a/pkg/connections/stomp/subscribe.go
+++ b/pkg/connections/stomp/subscribe.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stomp
+
+import (
+	"github.com/go-stomp/stomp"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+)
+
+// Subscribe subscribes to a topic
+func (c Connection) Subscribe(topic string, callback func(m client.Message, topic string) error) (err error) {
+	var subscription *stomp.Subscription
+
+	// Receive messages:
+	subscription, err = c.connection.Subscribe(topic, stomp.AckAuto)
+	if err != nil {
+		// TODO: error
+		return
+	}
+
+	// Wait for messages:
+	for message := range subscription.C {
+		if message.Err != nil {
+			// TODO: error ?
+			break
+		}
+
+		callback(client.Message{Body: string(message.Body)}, topic)
+	}
+
+	return
+}


### PR DESCRIPTION
**Description**

Remove the need to import the "private" implementation of specific connection.

Did not actually moved the implementation into internal because I wanted to see the two ways 
side by side.

I made two example:
1. recive.go - use the new implementation.
2. send.go - use the old implemention.

Fixes: https://github.com/container-mgmt/messaging-library/issues/18



