### PR TITLE
Use topic instead of destination

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ import (
 // published on specific topic.
 func callback(m client.Message, topic string) (err error) {
 	glog.Infof(
-		"Received message from destination '%s':\n%s",
+		"Received message from topic '%s':\n%s",
 		topic,
 		m.Body,
 	)

--- a/cmd/messaging-tool/main.go
+++ b/cmd/messaging-tool/main.go
@@ -26,13 +26,13 @@ import (
 
 var (
 	// Global options:
-	brokerHost      string
-	brokerPort      int
-	destinationName string
-	userName        string
-	userPassword    string
-	useTLS          bool
-	insecureTLS     bool
+	brokerHost   string
+	brokerPort   int
+	topicName    string
+	userName     string
+	userPassword string
+	useTLS       bool
+	insecureTLS  bool
 
 	// Main command:
 	rootCmd = &cobra.Command{
@@ -64,10 +64,10 @@ func init() {
 		"The port number of the message server.",
 	)
 	flags.StringVar(
-		&destinationName,
-		"destination",
+		&topicName,
+		"topic",
 		"",
-		"The name of the destination.",
+		"The name of the topic.",
 	)
 	flags.StringVar(
 		&userName,

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -26,14 +26,14 @@ import (
 
 var receiveCmd = &cobra.Command{
 	Use:   "receive",
-	Short: "Receive messages from a destination",
-	Long:  "Receive messages from a destination.",
+	Short: "Receive messages from a topic",
+	Long:  "Receive messages from a topic.",
 	Run:   runReceive,
 }
 
 func callback(m client.Message, topic string) (err error) {
 	glog.Infof(
-		"Received message from destination '%s':\n%s",
+		"Received message from topic '%s':\n%s",
 		topic,
 		m.Body,
 	)
@@ -46,8 +46,8 @@ func runReceive(cmd *cobra.Command, args []string) {
 	var err error
 
 	// Check mandatory arguments:
-	if destinationName == "" {
-		glog.Errorf("The argument 'destination' is mandatory")
+	if topicName == "" {
+		glog.Errorf("The argument 'topic' is mandatory")
 		return
 	}
 
@@ -89,18 +89,18 @@ func runReceive(cmd *cobra.Command, args []string) {
 	)
 
 	// Receive messages:
-	err = c.Subscribe(destinationName, callback)
+	err = c.Subscribe(topicName, callback)
 	if err != nil {
 		glog.Errorf(
-			"Can't subscribe to destination '%s': %s",
-			destinationName,
+			"Can't subscribe to topic '%s': %s",
+			topicName,
 			err.Error(),
 		)
 		return
 	}
 	glog.Infof(
-		"Subscribed to destination '%s'",
-		destinationName,
+		"Subscribed to topic '%s'",
+		topicName,
 	)
 	return
 }

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -35,8 +35,8 @@ var (
 
 var sendCmd = &cobra.Command{
 	Use:   "send",
-	Short: "Sends a message to a destination",
-	Long:  "Sends a message to a destination.",
+	Short: "Sends a message to a topic",
+	Long:  "Sends a message to a topic.",
 	Run:   runSend,
 }
 
@@ -71,8 +71,8 @@ func runSend(cmd *cobra.Command, args []string) {
 	var err error
 
 	// Check mandatory arguments:
-	if destinationName == "" {
-		glog.Errorf("The argument 'destination' is mandatory")
+	if topicName == "" {
+		glog.Errorf("The argument 'topic' is mandatory")
 		return
 	}
 
@@ -116,6 +116,8 @@ func runSend(cmd *cobra.Command, args []string) {
 	// Load the message body:
 	var body string
 	if messageBody == "" {
+		glog.Info("Please insert message body:")
+
 		bodyBytes, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			glog.Errorf(
@@ -148,11 +150,11 @@ func runSend(cmd *cobra.Command, args []string) {
 		}
 
 		glog.Info(body)
-		err = c.Publish(m, destinationName)
+		err = c.Publish(m, topicName)
 		if err != nil {
 			glog.Errorf(
-				"Can't send message to destination '%s': %s",
-				destinationName,
+				"Can't send message to topic '%s': %s",
+				topicName,
 				err.Error(),
 			)
 			break


### PR DESCRIPTION
**Description**

In our messaging-tool example we use the name `destination` to describe our `topic`, this can confuse users that will see the name `topic` inside the lib.

