### PR TITLE
Use destination instead of topic

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link
 
 This package provides a Go library that simplifies the implementation of
 communication patterns, like request/reply, on top of a messaging broker
-that supports queues and topics.
+that supports queues and topics (destinations).
 
 == Building
 
@@ -18,7 +18,7 @@ To build the example `messaging-tool` run the `make binaries` command.
 
 == Usage
 
-=== Publish a string message to a topic
+=== Publish a string message to a destination (queue or topic)
 
 Example:
 link:/cmd/messaging-tool/send.go[send.go]
@@ -54,11 +54,11 @@ import (
     Body:        "Hello subscriber.",
   }
 
-  // Publish our hello message to the "topic name" topic.
-  err = c.Publish(m, "topic name")
+  // Publish our hello message to the "destination name" destination.
+  err = c.Publish(m, "destination name")
 ----
 
-=== Subscribe to a topic
+=== Subscribe to a destination (queue or topic)
 
 Example:
 link:/cmd/messaging-tool/receive.go[receive.go]
@@ -80,11 +80,11 @@ import (
 ...
 
 // we will use this function as a callback function for each new message
-// published on specific topic.
-func callback(m client.Message, topic string) (err error) {
+// published on specific destination.
+func callback(m client.Message, destination string) (err error) {
 	glog.Infof(
-		"Received message from topic '%s':\n%s",
-		topic,
+		"Received message from destination '%s':\n%s",
+		destination,
 		m.Body,
 	)
 
@@ -106,7 +106,7 @@ func callback(m client.Message, topic string) (err error) {
 
   ...
 
-  // Subscribe to the topic "topic name", and run callback function for each
+  // Subscribe to the destination "destination name", and run callback function for each
   // new message.
-  err = c.Subscribe("topic name", callback)
+  err = c.Subscribe("destination name", callback)
 ----

--- a/cmd/messaging-tool/main.go
+++ b/cmd/messaging-tool/main.go
@@ -28,7 +28,7 @@ var (
 	// Global options:
 	brokerHost   string
 	brokerPort   int
-	topicName    string
+	destinationName    string
 	userName     string
 	userPassword string
 	useTLS       bool
@@ -64,10 +64,10 @@ func init() {
 		"The port number of the message server.",
 	)
 	flags.StringVar(
-		&topicName,
-		"topic",
+		&destinationName,
+		"destination",
 		"",
-		"The name of the topic.",
+		"The name of the destination.",
 	)
 	flags.StringVar(
 		&userName,

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -26,15 +26,15 @@ import (
 
 var receiveCmd = &cobra.Command{
 	Use:   "receive",
-	Short: "Receive messages from a topic",
-	Long:  "Receive messages from a topic.",
+	Short: "Receive messages from a destination",
+	Long:  "Receive messages from a destination.",
 	Run:   runReceive,
 }
 
-func callback(m client.Message, topic string) (err error) {
+func callback(m client.Message, destination string) (err error) {
 	glog.Infof(
-		"Received message from topic '%s':\n%s",
-		topic,
+		"Received message from destination '%s':\n%s",
+		destination,
 		m.Body,
 	)
 
@@ -46,8 +46,8 @@ func runReceive(cmd *cobra.Command, args []string) {
 	var err error
 
 	// Check mandatory arguments:
-	if topicName == "" {
-		glog.Errorf("The argument 'topic' is mandatory")
+	if destinationName == "" {
+		glog.Errorf("The argument 'destination' is mandatory")
 		return
 	}
 
@@ -89,18 +89,18 @@ func runReceive(cmd *cobra.Command, args []string) {
 	)
 
 	// Receive messages:
-	err = c.Subscribe(topicName, callback)
+	err = c.Subscribe(destinationName, callback)
 	if err != nil {
 		glog.Errorf(
-			"Can't subscribe to topic '%s': %s",
-			topicName,
+			"Can't subscribe to destination '%s': %s",
+			destinationName,
 			err.Error(),
 		)
 		return
 	}
 	glog.Infof(
-		"Subscribed to topic '%s'",
-		topicName,
+		"Subscribed to destination '%s'",
+		destinationName,
 	)
 	return
 }

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -35,8 +35,8 @@ var (
 
 var sendCmd = &cobra.Command{
 	Use:   "send",
-	Short: "Sends a message to a topic",
-	Long:  "Sends a message to a topic.",
+	Short: "Sends a message to a destination",
+	Long:  "Sends a message to a destination.",
 	Run:   runSend,
 }
 
@@ -71,8 +71,8 @@ func runSend(cmd *cobra.Command, args []string) {
 	var err error
 
 	// Check mandatory arguments:
-	if topicName == "" {
-		glog.Errorf("The argument 'topic' is mandatory")
+	if destinationName == "" {
+		glog.Errorf("The argument 'destination' is mandatory")
 		return
 	}
 
@@ -150,11 +150,11 @@ func runSend(cmd *cobra.Command, args []string) {
 		}
 
 		glog.Info(body)
-		err = c.Publish(m, topicName)
+		err = c.Publish(m, destinationName)
 		if err != nil {
 			glog.Errorf(
-				"Can't send message to topic '%s': %s",
-				topicName,
+				"Can't send message to destination '%s': %s",
+				destinationName,
 				err.Error(),
 			)
 			break

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package client contains the types and functions used to communicate with other services using
-// queues and topics.
+// queues and destinations.
 package client
 
 // Connection represents the logical connection between the program and the messaging system. This
@@ -31,9 +31,9 @@ type Connection interface {
 	// connection can't be reused.
 	Close() error
 
-	// Publish a message to a topic
-	Publish(m Message, topic string) error
+	// Publish a message to a destination
+	Publish(m Message, destination string) error
 
-	// Subscribe subscribes to a topic
-	Subscribe(topic string, callback func(m Message, topic string) error) error
+	// Subscribe subscribes to a destination
+	Subscribe(destination string, callback func(m Message, destination string) error) error
 }

--- a/pkg/connections/stomp/publish.go
+++ b/pkg/connections/stomp/publish.go
@@ -19,13 +19,13 @@ import (
 	"github.com/container-mgmt/messaging-library/pkg/client"
 )
 
-// Publish a message to a topic
-func (c *Connection) Publish(m client.Message, topic string) (err error) {
+// Publish a message to a destination
+func (c *Connection) Publish(m client.Message, destination string) (err error) {
 	body := []byte(m.Body)
 	contentType := m.ContentType
 
 	err = c.connection.Send(
-		topic,
+		destination,
 		contentType,
 		body,
 		stomp.SendOpt.Header("persistent", "true"),

--- a/pkg/connections/stomp/subscribe.go
+++ b/pkg/connections/stomp/subscribe.go
@@ -19,12 +19,12 @@ import (
 	"github.com/container-mgmt/messaging-library/pkg/client"
 )
 
-// Subscribe subscribes to a topic
-func (c *Connection) Subscribe(topic string, callback func(m client.Message, topic string) error) (err error) {
+// Subscribe subscribes to a destination
+func (c *Connection) Subscribe(destination string, callback func(m client.Message, destination string) error) (err error) {
 	var subscription *stomp.Subscription
 
 	// Receive messages:
-	subscription, err = c.connection.Subscribe(topic, stomp.AckAuto)
+	subscription, err = c.connection.Subscribe(destination, stomp.AckAuto)
 	if err != nil {
 		// TODO: error
 		return
@@ -37,7 +37,7 @@ func (c *Connection) Subscribe(topic string, callback func(m client.Message, top
 			break
 		}
 
-		callback(client.Message{Body: string(message.Body)}, topic)
+		callback(client.Message{Body: string(message.Body)}, destination)
 	}
 
 	return


### PR DESCRIPTION
**Description**

In our client we do not know if the broker is configured to use some `destination` as a `queue` or as a `topic` [*].

Using the name `destination` for queues and topics will indicate to users that we do not know, what type this `destination` is configured to be in the broker.

[*] in artimis mq this is done using a configuration file:
https://access.redhat.com/documentation/en-us/red_hat_amq/7.1/html/using_amq_broker/addresses

