### PR TITLE
Godoc wants only one docstring per package

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,7 @@
 
 image:https://travis-ci.org/container-mgmt/messaging-library.svg?branch=master["Build Status", link="https://travis-ci.org/container-mgmt/messaging-library"]
 image:https://goreportcard.com/badge/container-mgmt/messaging-library["Go Report Card", link="https://goreportcard.com/report/github.com/container-mgmt/messaging-library"]
+image:https://godoc.org/github.com/container-mgmt/messaging-library/pkg/client?status.svg["GoDoc", link="https://godoc.org/github.com/container-mgmt/messaging-library/pkg/client"]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://opensource.org/licenses/Apache-2.0"]
 
 This package provides a Go library that simplifies the implementation of

--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -11,8 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package client contains the types and functions used to communicate with other services using
-// queues and topics.
 package client
 
 // Message is an implementation of Message interface

--- a/pkg/connections/stomp/connection.go
+++ b/pkg/connections/stomp/connection.go
@@ -11,6 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package stomp contains an inplementation of a messaging-library/pkg/client
+// connection object used to communicate with a STOMP broker server.
+//
+// https://godoc.org/github.com/container-mgmt/messaging-library/pkg/client
 package stomp
 
 import (


### PR DESCRIPTION
**Description**

Godoc wants only one docstring per package.

This PR removes the duplicate docstring from the client package, and adds a missing docstring to the stomp package.

**Screenshot**
![screenshot-godoc org-2018-06-17-10-24-55](https://user-images.githubusercontent.com/2181522/41505781-d4412528-7218-11e8-80ee-ee02ae0c6717.png)

