### PR TITLE
Fix spelling

### DIFF
--- a/pkg/connections/stomp/connection.go
+++ b/pkg/connections/stomp/connection.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package stomp contains an inplementation of a messaging-library/pkg/client
+// Package stomp contains an implementation of a messaging-library/pkg/client
 // connection object used to communicate with a STOMP broker server.
 //
 // https://godoc.org/github.com/container-mgmt/messaging-library/pkg/client


### PR DESCRIPTION
**Description**

Fix spelling `s/inplementation/implementation/gi`
