### PR TITLE
Add a STOMP server example

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,11 @@
   name = "github.com/go-stomp/stomp"
   packages = [
     ".",
-    "frame"
+    "frame",
+    "server",
+    "server/client",
+    "server/queue",
+    "server/topic"
   ]
   revision = "ba860900ef3307ecfe85ca14bc4838f24cfc7126"
   version = "v2.0"
@@ -37,6 +41,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e84c9dc4a3e37ef7e89cd9f32d2289c09a0e302ddb22eaee1b5490e6d09a0903"
+  inputs-digest = "a09229cba603c68c2bd1d5c7ba735ec777b055d92a7a2669eade04bd66264343"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/messaging-server/main.go
+++ b/cmd/messaging-server/main.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	// Global options:
+	brokerHost   string
+	brokerPort   int
+	userName     string
+	userPassword string
+
+	// Main command:
+	rootCmd = &cobra.Command{
+		Use:  "messaging-server",
+		Long: "Your friendly STOMP broker (YFSB).",
+	}
+)
+
+func init() {
+	// Send logs to the standard error stream by default:
+	flag.Set("logtostderr", "true")
+
+	// Register the options that are managed by the 'flag' package, so that they will also be parsed
+	// by the 'pflag' package:
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	// Register the global options:
+	flags := rootCmd.PersistentFlags()
+	flags.StringVar(
+		&brokerHost,
+		"host",
+		"127.0.0.1",
+		"Default hostname for listening for connections.",
+	)
+	flags.IntVar(
+		&brokerPort,
+		"port",
+		61613,
+		"Default port for listening for connections.",
+	)
+	flags.StringVar(
+		&userName,
+		"user",
+		"",
+		"The name of the user.",
+	)
+	flags.StringVar(
+		&userPassword,
+		"password",
+		"",
+		"The password of the user.",
+	)
+
+	// Register the subcommands:
+	rootCmd.AddCommand(serveCmd)
+}
+
+func main() {
+	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
+	// every log messages is prefixed by an error message stating the the flags haven't been
+	// parsed.
+	flag.CommandLine.Parse([]string{})
+
+	// Execute the root command:
+	rootCmd.SetArgs(os.Args[1:])
+	rootCmd.Execute()
+}

--- a/cmd/messaging-server/serve.go
+++ b/cmd/messaging-server/serve.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/go-stomp/stomp/server"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Run a messages broker server",
+	Long:  "Run a messages broker server.",
+	Run:   runServe,
+}
+
+type myAuthenticator struct {
+	userName     string
+	userPasscode string
+}
+
+// Authenticate based on the given login and passcode, either of which might be nil.
+// Returns true if authentication is successful, false otherwise.
+func (m myAuthenticator) Authenticate(login, passcode string) bool {
+	if m.userName == "" {
+		return true
+	}
+	return login == m.userName && passcode == m.userPasscode
+}
+
+func (m myAuthenticator) Message() string {
+	if m.userName == "" {
+		return "listen to all"
+	}
+	return fmt.Sprintf(
+		"listen only to %s:%s",
+		m.userName,
+		m.userPasscode,
+	)
+}
+
+func runServe(cmd *cobra.Command, args []string) {
+	brokerAddress := fmt.Sprintf("%s:%d", brokerHost, brokerPort)
+	brokerAthenticator := myAuthenticator{
+		userName:     userName,
+		userPasscode: userPassword}
+	brokerServer := server.Server{
+		Addr:          brokerAddress,      // TCP address to listen on, DefaultAddr if empty
+		Authenticator: brokerAthenticator, // Authenticates login/passcodes. If nil no authentication is performed
+	}
+
+	// Indicate we are running.
+	glog.Infof(
+		"Your friendly STOMP broker (YFSB) server %s: [%s]",
+		brokerAddress,
+		brokerAthenticator.Message(),
+	)
+
+	// ListenAndServe listens on the TCP network address and handle requests on
+	// the incoming connections.
+	err := brokerServer.ListenAndServe()
+	if err != nil {
+		glog.Errorf(
+			"Can't start server on '%s': %s",
+			brokerAddress,
+			err.Error(),
+		)
+	}
+}


### PR DESCRIPTION
**Description**

Add a friendly STOMP server example.

**Rational**

We need a friendly server to test our library.

**Usage**

Get help:
``` bash
messaging-server -h
Your friendly STOMP broker (YFSB).
...
```

Serve requests:
``` bash
messaging-server serve
I0617 13:01:47.526398   31037 serve.go:71] Your friendly STOMP broker (YFSB) server 127.0.0.1:61613: [listen to all]
2018/06/17 13:01:57 connection closed: 127.0.0.1:44010
2018/06/17 13:02:12 connection closed: 127.0.0.1:44012
2018/06/17 13:02:15 connection closed: 127.0.0.1:44008
...
```