### PR TITLE
Fix ineffectual assignment of bodyBytes

### DIFF
--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -126,6 +126,7 @@ func runSend(cmd *cobra.Command, args []string) {
 			)
 			return
 		}
+		body = string(bodyBytes)
 	} else if messageBody[0] == '@' {
 		messageFile := messageBody[1:]
 		bodyBytes, err = ioutil.ReadFile(messageFile)


### PR DESCRIPTION
**Description**

Fix ineffectual assignment of bodyBytes. In the send example we read a string from user input, but we never use this string as the message body.