### PR TITLE
Fix return value from callback in send example

### DIFF
--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -33,10 +33,11 @@ var receiveCmd = &cobra.Command{
 
 func callback(message client.Message, destination string) (err error) {
 	if message.Err != nil {
+		err = message.Err
 		glog.Errorf(
 			"Can't subscribe to destination '%s': %s",
 			destinationName,
-			message.Err.Error(),
+			err.Error(),
 		)
 		return
 	}


### PR DESCRIPTION
**Description**

In send example callback we should return an error if an error is received (thanks @cben).  

FIx issue: https://github.com/container-mgmt/messaging-library/pull/26/files#r195936371