### PR TITLE
Use json message body

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,10 +78,18 @@ import (
   err = c.Open()
   defer c.Close()
 
-  // Make a message with plain text body "Hello subscriber.".
+  // Set some text to the message.
+  messageText := "Hello world"
+
+  // Create a data object to send to the message broker,
+  // a data payload must be of type map[string]interface{}.
+  data := make(map[string]interface{}, 0)
+  data["kind"] = "InfoMessage"
+  data["spec"] = map[string]string{"message": messageText}
+
+  // Make a message using the data object we created.
   m = client.Message{
-    ContentType: "text/plain",
-    Body:        "Hello subscriber.",
+    Data:        data
   }
 
   // Publish our hello message to the "destination name" destination.
@@ -111,11 +119,13 @@ import (
 
 // We will use this function as a callback function for each new message
 // published on specific destination.
+//
+// m.Data is of type map[string]interface{}
 func callback(m client.Message, destination string) (err error) {
 	glog.Infof(
-		"Received message from destination '%s':\n%s",
+		"Received message from destination '%s':\n%v",
 		destination,
-		m.Body,
+		m.Data,
 	)
 
 	return

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -43,9 +43,9 @@ func callback(message client.Message, destination string) (err error) {
 	}
 
 	glog.Infof(
-		"Received message from destination '%s':\n%s",
+		"Received message from destination '%s':\n%v",
 		destination,
-		message.Body,
+		message.Data,
 	)
 	return
 }

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -145,9 +145,12 @@ func runSend(cmd *cobra.Command, args []string) {
 
 	// Send a message:
 	for i := 0; i < messageCount; i++ {
+		data := make(map[string]interface{}, 0)
+		data["kind"] = "InfoMessage"
+		data["spec"] = map[string]string{"message": body}
+
 		m := client.Message{
-			ContentType: contentType,
-			Body:        body,
+			Data: data,
 		}
 
 		glog.Info(body)

--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -21,14 +21,14 @@ package client
 type Message struct {
 	// The message body, which is an a string.
 	// The ContentType indicates the format of this body.
-	Body string // Content of message
+	Data map[string]interface{} // Content of message
 
 	// MIME content type.
 	ContentType string // MIME of the message, usually "text/plain"
 
 	// Indicates whether an error was received on the subscription.
 	// The error will contain details of the error. If the server
-	// sent an ERROR frame, then the Body, ContentType and Header fields
+	// sent an ERROR frame, then the Data, ContentType and Header fields
 	// will be populated according to the contents of the ERROR frame.
 	Err error
 }

--- a/pkg/connections/stomp/publish.go
+++ b/pkg/connections/stomp/publish.go
@@ -14,6 +14,7 @@ limitations under the License.
 package stomp
 
 import (
+	"encoding/json"
 	"github.com/go-stomp/stomp"
 
 	"github.com/container-mgmt/messaging-library/pkg/client"
@@ -23,8 +24,19 @@ import (
 // message to the specified destination. If the messaging server fails to
 // receive the message for any reason, the connection will close.
 func (c *Connection) Publish(m client.Message, destination string) (err error) {
-	body := []byte(m.Body)
+	var body []byte
+
+	// Marshal the message body (type: map[string]interface{}) into a byte array.
+	body, err = json.Marshal(m.Data)
+	if err != nil {
+		return
+	}
+
+	// Our default contentType is "application/json"
 	contentType := m.ContentType
+	if contentType == "" {
+		contentType = "application/json"
+	}
 
 	err = c.connection.Send(
 		destination,


### PR DESCRIPTION
**Description**

Use json message body, this should play better for our use cases.

**Example**

``` go
  body := "Hello world"
  // Create a data object to send to the message broker,
  // a data payload must be of type map[string]interface{}.
  data := make(map[string]interface{}, 0)
  data["kind"] = "InfoMessage"
  data["spec"] = map[string]string{"message": body}

  // Publish our data object to the "some-queue-name" destination.
  err = c.Publish(client.Message{ Data: data }, "some-queue-name")
```