### PR TITLE
Add message content type

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,6 +65,12 @@ import (
   "github.com/container-mgmt/messaging-library/pkg/connections/stomp"
 )
 
+// Declare our data type, we will use it when we send the message.
+type dataPayload struct {
+  kind string
+  spec map[string]string
+}
+
 ...
 
   // Create a new connection object.
@@ -82,10 +88,11 @@ import (
   messageText := "Hello world"
 
   // Create a data object to send to the message broker,
-  // a data payload must be of type map[string]interface{}.
-  data := make(map[string]interface{}, 0)
-  data["kind"] = "InfoMessage"
-  data["spec"] = map[string]string{"message": messageText}
+  // a data payload can be of any type (here we use `dataPayload` type).
+  data := dataPayload{
+    kind: "InfoMessage",
+    spec: map[string]string{"message": messageText},
+  }
 
   // Make a message using the data object we created.
   m = client.Message{

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -40,6 +40,11 @@ var sendCmd = &cobra.Command{
 	Run:   runSend,
 }
 
+type dataPayload struct {
+	kind string
+	spec map[string]string
+}
+
 func init() {
 	flags := sendCmd.Flags()
 	flags.StringVar(
@@ -145,9 +150,10 @@ func runSend(cmd *cobra.Command, args []string) {
 
 	// Send a message:
 	for i := 0; i < messageCount; i++ {
-		data := make(map[string]interface{}, 0)
-		data["kind"] = "InfoMessage"
-		data["spec"] = map[string]string{"message": body}
+		data := dataPayload{
+			kind: "InfoMessage",
+			spec: map[string]string{"message": body},
+		}
 
 		m := client.Message{
 			Data: data,

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -20,6 +20,9 @@ limitations under the License.
 // In this library we use the term destinations to describe both queues and topics.
 package client
 
+// SubscriptionCallback is the callback function type used for subscription callback.
+type SubscriptionCallback func(m Message, destination string) error
+
 // Connection represents the logical connection between the program and the messaging system. This
 // logical connection may correspond to one or multiple physical connections, depending on the
 // underlying protocol and implementation.
@@ -44,7 +47,7 @@ type Connection interface {
 	// will be received by this subscription.
 	//
 	// Once a message or an error is recived, the callback function will be trigered.
-	Subscribe(destination string, callback func(m Message, destination string) error) error
+	Subscribe(destination string, callback SubscriptionCallback) error
 
 	// Unsubscribe unsubscribes from a destination
 	Unsubscribe(destination string) error

--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -13,6 +13,9 @@ limitations under the License.
 
 package client
 
+// MessageData is the message payload data type.
+type MessageData interface{}
+
 // Message represents a message sent or received by a connection.
 // In most cases a message corresponds to a single message sent or received by
 // a connection. If, however, the Err field is non-nil, then the message
@@ -21,7 +24,7 @@ package client
 type Message struct {
 	// The message body, which is an a string.
 	// The ContentType indicates the format of this body.
-	Data map[string]interface{} // Content of message
+	Data MessageData // Content of message
 
 	// MIME content type.
 	ContentType string // MIME of the message, usually "text/plain"

--- a/pkg/connections/stomp/subscribe.go
+++ b/pkg/connections/stomp/subscribe.go
@@ -27,9 +27,9 @@ import (
 // will be received by this subscription.
 //
 // Once a message or an error is recived, the callback function will be trigered.
-func (c *Connection) Subscribe(destination string, callback func(m client.Message, destination string) error) (err error) {
+func (c *Connection) Subscribe(destination string, callback client.SubscriptionCallback) (err error) {
 	var subscription *stomp.Subscription
-	var body map[string]interface{}
+	var data client.MessageData
 
 	// Check if we already subscibe to this destination,
 	// We do not allow for multiple subscriptions for one destination.
@@ -50,7 +50,7 @@ func (c *Connection) Subscribe(destination string, callback func(m client.Messag
 	for message := range subscription.C {
 		// Try to unmarshal the byte array comming from the broker into a
 		// message body of type map[string]interface{}
-		err = json.Unmarshal(message.Body, &body)
+		err = json.Unmarshal(message.Body, &data)
 		if err != nil {
 			// Call the callback function with the json unmarshal error.
 			callback(
@@ -62,7 +62,7 @@ func (c *Connection) Subscribe(destination string, callback func(m client.Messag
 		// Call the callback function.
 		callback(
 			client.Message{
-				Data: body,
+				Data: data,
 				Err:  message.Err},
 			destination)
 	}


### PR DESCRIPTION
**Description**

Add message content type. Currently we use base types for the message, this is not nice.

Fixes: https://github.com/container-mgmt/messaging-library/pull/37#pullrequestreview-129466322