### PR TITLE
Add a low level publish function

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,12 +65,6 @@ import (
   "github.com/container-mgmt/messaging-library/pkg/connections/stomp"
 )
 
-// Declare our data type, we will use it when we send the message.
-type dataPayload struct {
-  kind string
-  spec map[string]string
-}
-
 ...
 
   // Create a new connection object.
@@ -88,10 +82,10 @@ type dataPayload struct {
   messageText := "Hello world"
 
   // Create a data object to send to the message broker,
-  // a data payload can be of any type (here we use `dataPayload` type).
-  data := dataPayload{
-    kind: "InfoMessage",
-    spec: map[string]string{"message": messageText},
+  // a data payload must be of type client.MessageData{}.
+  data := client.MessageData{
+    "kind": "hello",
+    "spec": map[string]string{"message": messageText},
   }
 
   // Make a message using the data object we created.

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -35,7 +35,7 @@ func callback(message client.Message, destination string) (err error) {
 	if message.Err != nil {
 		err = message.Err
 		glog.Errorf(
-			"Can't subscribe to destination '%s': %s",
+			"Received error from destination '%s': %s",
 			destinationName,
 			err.Error(),
 		)

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -40,11 +40,6 @@ var sendCmd = &cobra.Command{
 	Run:   runSend,
 }
 
-type dataPayload struct {
-	kind string
-	spec map[string]string
-}
-
 func init() {
 	flags := sendCmd.Flags()
 	flags.StringVar(
@@ -150,9 +145,9 @@ func runSend(cmd *cobra.Command, args []string) {
 
 	// Send a message:
 	for i := 0; i < messageCount; i++ {
-		data := dataPayload{
-			kind: "InfoMessage",
-			spec: map[string]string{"message": body},
+		data := client.MessageData{
+			"kind": "hello",
+			"spec": map[string]string{"message": body},
 		}
 
 		m := client.Message{

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -40,6 +40,14 @@ type Connection interface {
 	// Publish sends a message to the messaging server, which in turn sends the
 	// message to the specified destination. If the messaging server fails to
 	// receive the message for any reason, the connection will close.
+	//
+	// the function check if we have a byteArray key, if we do we will overide the
+	// object abstruction mechanism, and send the byteArray to the server as is.
+	// e.g.
+	//   // The next lines will send {data: message} to the server.
+	//   data := client.MessageData{
+	//     "byteArray": []byte("\"data\": \"message\""),
+	//   }
 	Publish(m Message, destination string) error
 
 	// Subscribe creates a subscription on the messaging server.

--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -14,7 +14,7 @@ limitations under the License.
 package client
 
 // MessageData is the message payload data type.
-type MessageData interface{}
+type MessageData map[string]interface{}
 
 // Message represents a message sent or received by a connection.
 // In most cases a message corresponds to a single message sent or received by


### PR DESCRIPTION
**Description**

A.
**Bug**: we currently use `interface{}` as the type of the Message data, when we pass any custom struct to the Message data, it looses it's keys and we end up with a "blind" struct that convert to empty json.
This does not happen if we use `map[string]interface{}` as Message data.
 
This PR return data to the working `map[string]interface{}` type.

Investigating why keys are lost (I didn't find out why)

B.
Add a low level publish function, currently we do not have a way to bypass the object abstraction when sending a message, this function adds the option to send low level byte array to the message broker if needed. 