### PR TITLE
Add inline documentation to send example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,16 +81,13 @@ import (
   // Set some text to the message.
   messageText := "Hello world"
 
-  // Create a data object to send to the message broker,
-  // a data payload must be of type client.MessageData{}.
-  data := client.MessageData{
-    "kind": "hello",
-    "spec": map[string]string{"message": messageText},
-  }
-
-  // Make a message using the data object we created.
-  m = client.Message{
-    Data:        data
+  // Create a message with data object to send to the message broker,
+  // the data payload must be of type client.MessageData{}.
+  m := client.Message{
+    Data: client.MessageData{
+      "kind": "helloMessage",
+      "spec": map[string]string{"message": messageText},
+    },
   }
 
   // Publish our hello message to the "destination name" destination.
@@ -121,7 +118,7 @@ import (
 // We will use this function as a callback function for each new message
 // published on specific destination.
 //
-// m.Data is of type map[string]interface{}
+// m.Data is of type client.MessageData{}
 func callback(m client.Message, destination string) (err error) {
 	glog.Infof(
 		"Received message from destination '%s':\n%v",

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -45,7 +45,7 @@ func init() {
 	flags.StringVar(
 		&contentType,
 		"content-type",
-		"text/plain",
+		"application/json",
 		"The MIME type of the message body.",
 	)
 	flags.StringVar(
@@ -143,18 +143,22 @@ func runSend(cmd *cobra.Command, args []string) {
 		body = messageBody
 	}
 
+	// Inform user about the message body.
+	glog.Infof("Message: %s", body)
+
 	// Send a message:
 	for i := 0; i < messageCount; i++ {
-		data := client.MessageData{
-			"kind": "hello",
-			"spec": map[string]string{"message": body},
-		}
-
+		// Create a message with data object to send to the message broker,
+		// the data payload must be of type client.MessageData{}.
 		m := client.Message{
-			Data: data,
+			ContentType: contentType,
+			Data: client.MessageData{
+				"kind": "InfoMessage",
+				"spec": map[string]string{"message": body},
+			},
 		}
 
-		glog.Info(body)
+		// Send message to messaging broker.
 		err = c.Publish(m, destinationName)
 		if err != nil {
 			glog.Errorf(

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -21,6 +21,28 @@ limitations under the License.
 package client
 
 // SubscriptionCallback is the callback function type used for subscription callback.
+// The callback function is used when subscribing to a destination, it is the
+// function that will triger in the event of a message or an error frame.
+//
+// For example:
+//   func callback(message client.Message, destination string) (err error) {
+//  	if message.Err != nil {
+//  		err = message.Err
+//  		glog.Errorf(
+//  			"Received error from destination '%s': %s",
+//  			destinationName,
+//  			err.Error(),
+//  		)
+//  		return
+//  	}
+//
+//  	glog.Infof(
+//  		"Received message from destination '%s':\n%v",
+//  		destination,
+//  		message.Data,
+//  	)
+//  	return
+//  }
 type SubscriptionCallback func(m Message, destination string) error
 
 // Connection represents the logical connection between the program and the messaging system. This
@@ -40,11 +62,23 @@ type Connection interface {
 	// Publish sends a message to the messaging server, which in turn sends the
 	// message to the specified destination. If the messaging server fails to
 	// receive the message for any reason, the connection will close.
+	// e.g.
+	//   // The next lines will send a MessageData{} object to the server.
+	//   err = c.Publish(
+	//     client.Message{
+	//       Data: client.MessageData{
+	//         "some-key": "some-value",
+	//         "other-key": "other-value",
+	//       },
+	//       ContentType: "application/json", // Default is "application/json"
+	//     },
+	//     "queue-name",
+	//   )
 	//
 	// the function check if we have a byteArray key, if we do we will overide the
 	// object abstraction mechanism, and send the byteArray to the server as is.
 	// e.g.
-	//   // The next lines will send {data: message} to the server.
+	//   // The next lines will send a byte array to the server.
 	//   data := client.MessageData{
 	//     "byteArray": []byte("\"data\": \"message\""),
 	//   }

--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -14,6 +14,12 @@ limitations under the License.
 package client
 
 // MessageData is the message payload data type.
+//
+// For example:
+//   data := client.MessageData{
+//    "kind": "InfoMessage",
+//    "spec": map[string]string{"message": body},
+//   }
 type MessageData map[string]interface{}
 
 // Message represents a message sent or received by a connection.
@@ -27,7 +33,7 @@ type Message struct {
 	Data MessageData // Content of message
 
 	// MIME content type.
-	ContentType string // MIME of the message, usually "text/plain"
+	ContentType string // MIME of the message, usually "application/json"
 
 	// Indicates whether an error was received on the subscription.
 	// The error will contain details of the error. If the server


### PR DESCRIPTION
**Description**

a. Add in-line documentation.
b. Add examples to in-line documentation.
c. Tidy the message object in the send example.

