### PR TITLE
In case of jason parse error return the raw data to user

### DIFF
--- a/pkg/connections/stomp/subscribe.go
+++ b/pkg/connections/stomp/subscribe.go
@@ -55,7 +55,8 @@ func (c *Connection) Subscribe(destination string, callback client.SubscriptionC
 			// Call the callback function with the json unmarshal error.
 			callback(
 				client.Message{
-					Err: err},
+					Data: client.MessageData{"byteArray": message.Body},
+					Err:  err},
 				destination)
 		}
 


### PR DESCRIPTION
**Description**

Currently in case the raw bytes of a message is not a valid json object, we get an error, but we do not get the raw bytes. This PR adds the raw bytes to the returned frame.