### PR TITLE
Remove unneeded blobs from readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,16 +11,19 @@ that supports queues and topics (destinations).
 
 == Building
 
-To build the project clone the repository to your go path and run the
-`make` command.
+To build the project clone the repository to your go path, you can use the regular
+go tools to build and install the examples.
 
-To build the example `messaging-tool` and a testing broker `messaging-server`
-run the `make binaries` command.
+To run the example `messaging-tool` and a testing broker `messaging-server`,
+users can build and install, or run without installing:
 
-The `make binaries` command will install the binaries into `./.gopath/bin/` path
-instead of `$GOPATH/bin` or `$GOBIN`, when executing the examples below use the
-correct path (e.g. run `./.gopath/bin/messaging-server` if `./.gopath/bin` is not in
-your `$PATH`).
+``` Bash
+$ # Run demo server without installing
+$ go run cmd/messaging-server/*.go --help
+$
+$ # Run demo example without installing
+$ go run cmd/messaging-tool/*.go --help
+```
 
 === Examples
 

--- a/cmd/messaging-server/README.adoc
+++ b/cmd/messaging-server/README.adoc
@@ -4,13 +4,13 @@ A memory based STOMP broker for testing of the messaging library.
 
 == Building
 
-To build the example `messaging-tool` and a testing broker `messaging-server`
-run the `make binaries` command.
+Use the regular go tools to build and install the examples, or run the
+example `messaging-server`, without install:
 
-The `make binaries` command will install the binaries into `./.gopath/bin/` path
-instead of `$GOPATH/bin` or `$GOBIN`, when executing the examples below use the
-correct path (e.g. run `./.gopath/bin/messaging-server` if `./.gopath/bin` is not in
-your `$PATH`).
+``` Bash
+$ # Run demo server without installing
+$ go run cmd/messaging-server/*.go --help
+```
 
 == Usage
 

--- a/cmd/messaging-tool/README.adoc
+++ b/cmd/messaging-tool/README.adoc
@@ -4,13 +4,13 @@ A tool that can send and receive messages using a message broker.
 
 == Building
 
-To build the example `messaging-tool` and a testing broker `messaging-server`
-run the `make binaries` command.
+Use the regular go tools to build and install the examples, or run the
+example `messaging-tool`, without install:
 
-The `make binaries` command will install the binaries into `./.gopath/bin/` path
-instead of `$GOPATH/bin` or `$GOBIN`, when executing the examples below use the
-correct path (e.g. run `./.gopath/bin/messaging-server` if `./.gopath/bin` is not in
-your `$PATH`).
+``` Bash
+$ # Run demo example without installing
+$ go run cmd/messaging-tool/*.go --help
+```
 
 == Usage
 


### PR DESCRIPTION
**Description**

In the readme file we currently have a text blob to help users overcome the makefile's command's unexpected install path [1]. This PR removes the unneeded blob and directs users to use the regular go tool chain.

[1] https://github.com/container-mgmt/messaging-library/pull/32#issuecomment-397881685