### PR TITLE
Fix copyright headers

### DIFF
--- a/pkg/client/message.go
+++ b/pkg/client/message.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) 2018 Red Hat, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
   http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/connections/stomp/connection.go
+++ b/pkg/connections/stomp/connection.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) 2018 Red Hat, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
   http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/connections/stomp/connection_builder.go
+++ b/pkg/connections/stomp/connection_builder.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) 2018 Red Hat, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
   http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/connections/stomp/connection_test.go
+++ b/pkg/connections/stomp/connection_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) 2018 Red Hat, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
   http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/connections/stomp/publish.go
+++ b/pkg/connections/stomp/publish.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) 2018 Red Hat, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
   http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/connections/stomp/subscribe.go
+++ b/pkg/connections/stomp/subscribe.go
@@ -1,9 +1,12 @@
 /*
 Copyright (c) 2018 Red Hat, Inc.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
   http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This patch fixes some of the copyright headers, so that all the files have exactly the same.