### PR TITLE
Create the Requestor/Responder API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,6 +27,12 @@
   version = "v1.0"
 
 [[projects]]
+  name = "github.com/segmentio/ksuid"
+  packages = ["."]
+  revision = "112f929a3020abfcd06b77c963ec919130796a35"
+  version = "1.0.1"
+
+[[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
@@ -41,6 +47,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a09229cba603c68c2bd1d5c7ba735ec777b055d92a7a2669eade04bd66264343"
+  inputs-digest = "d291ae932b1038b48eafaa1d3bec15696bc9e8cd4930ddea2809e66c42271430"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,3 +13,7 @@
 [[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.2"
+
+[[constraint]]
+  name = "github.com/segmentio/ksuid"
+  version = "1.0.1"

--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,8 @@ link:/cmd/messaging-tool/[messaging-tool]
 
 link:/cmd/messaging-server/[messaging-server]
 
+link:/cmd/request-tool/[request-tool]
+
 === Running
 
 Run `messaging-server` testing Server:
@@ -51,6 +53,20 @@ Run `messaging-tool` testing tool, and send a messages:
 [source]
 ----
 $ messaging-tool send --host 127.0.0.1 --destination "hello" --body "world"
+----
+
+Run `request-tool` testing tool, and start the request echo-server:
+
+[source]
+----
+$ request-tool respond --host 127.0.0.1 --requests-queue "requests"
+----
+
+Run `request-tool` testing tool, and send a request:
+
+[source]
+----
+$ request-tool send --host 127.0.0.1 --requests-queue "requests" --responses-queue "response1" --body "my request"
 ----
 
 == Usage
@@ -159,6 +175,157 @@ defer c.Close()
 // new message.
 err = c.Subscribe("destination name", callback)
 ----
+
+
+=== Create a responder on a queue
+
+Example:
+
+link:/cmd/request-tool/respond.go[respond.go]
+
+[source,go]
+----
+import (
+	...
+
+	// Import the message broker client interface.
+	"github.com/container-mgmt/messaging-library/pkg/client"
+
+	// Import a STOMP client implementation.
+	"github.com/container-mgmt/messaging-library/pkg/connections/stomp"
+)
+
+...
+
+// We will use this function as a callback function for each new reqquest
+// received on the queue.
+//
+// request.Data is of type client.MessageData{}
+func requestHandler(request client.Message) (response client.Message, err error) {
+	glog.Infof(
+		"Received request:\n%v",
+		request.Data,
+	)
+
+	return
+}
+
+...
+
+// Create a new connection object.
+var c client.Connection
+
+// Set a new STOMP connction to localhost:1888.
+c, err = stomp.NewConnection(&client.ConnectionSpec{
+	BrokerHost: "localhost",
+	BrokerPort: 1888,
+})
+if err != nil {
+	...
+}
+defer c.Close()
+
+...
+
+// Create a responder on the responses queue
+r, err := c.NewResponder(
+	client.ResponderSpec{
+		RequestsQueue: "requests-queue",
+		Callback:      requestHandler,
+	})
+
+if err != nil {
+	...
+}
+
+defer r.Close()
+...
+----
+
+
+=== Create a requestor that sends requests to a queue
+
+Example:
+
+link:/cmd/request-tool/request.go[request.go]
+
+[source,go]
+----
+import (
+	...
+
+	// Import the message broker client interface.
+	"github.com/container-mgmt/messaging-library/pkg/client"
+
+	// Import a STOMP client implementation.
+	"github.com/container-mgmt/messaging-library/pkg/connections/stomp"
+)
+
+...
+
+// We will use this function as a callback function a response
+// received on the responses queue.
+//
+// response.Data is of type client.MessageData{}
+func responseHandler(response client.Message, requestID string) (err error) {
+	glog.Infof(
+		"Received response for request id: %s:\n%v",
+		requestID,
+		response.Data,
+	)
+
+	return
+}
+
+...
+
+// Create a new connection object.
+var c client.Connection
+
+// Set a new STOMP connction to localhost:1888.
+c, err = stomp.NewConnection(&client.ConnectionSpec{
+	BrokerHost: "localhost",
+	BrokerPort: 1888,
+})
+if err != nil {
+	...
+}
+defer c.Close()
+
+...
+
+// Create a requestor that sends requests to the requests-queue
+// and receives responses on the responses queue
+r, err := c.NewRequestor(
+	client.RequestorSpec{
+		RequestsQueue:  "requests-queue",
+		ResponsesQueue: "responses-queue",
+	})
+
+if err != nil {
+	...
+}
+
+defer r.Close()
+...
+
+// Send a request:
+// Message data is a map [string]interface and can be populated
+// with any data of that structure
+request := client.Message{
+	ContentType: contentType,
+	Data: client.MessageData{
+		"kind": "Request",
+		"message": "this is my request"},
+	},
+}
+
+// Send the request, and set the handler for the response
+r.Send(m, responseHandler)
+
+
+----
+
 
 === Running Tests and Benchmarks
 

--- a/cmd/request-tool/README.adoc
+++ b/cmd/request-tool/README.adoc
@@ -1,0 +1,31 @@
+= messaging-tool
+
+A tool that can send and receive messages using a message broker.
+
+== Building
+
+To build the example `request-tool` and a testing broker `messaging-server`
+run the `make binaries` command.
+
+The `make binaries` command will install the binaries into `./.gopath/bin/` path
+instead of `$GOPATH/bin` or `$GOBIN`, when executing the examples below use the
+correct path (e.g. run `./.gopath/bin/messaging-server` if `./.gopath/bin` is not in
+your `$PATH`).
+
+== Usage
+
+=== Running the examples
+
+Run `request-tool` testing tool, and start the request echo-server:
+
+[source]
+----
+$ request-tool respond --host 127.0.0.1 --requests-queue "requests"
+----
+
+Run `request-tool` testing tool, and send a request:
+
+[source]
+----
+$ request-tool send --host 127.0.0.1 --requests-queue "requests" --responses-queue "response1" --body "my request"
+----

--- a/cmd/request-tool/main.go
+++ b/cmd/request-tool/main.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	// Global options:
+	brokerHost     string
+	brokerPort     int
+	requestsQueue  string
+	responsesQueue string
+	userName       string
+	userPassword   string
+	useTLS         bool
+	insecureTLS    bool
+
+	// Main command:
+	rootCmd = &cobra.Command{
+		Use:  "request-tool",
+		Long: "A tool that can send requests and responses using a message broker.",
+	}
+)
+
+func init() {
+	// Send logs to the standard error stream by default:
+	flag.Set("logtostderr", "true")
+
+	// Register the options that are managed by the 'flag' package, so that they will also be parsed
+	// by the 'pflag' package:
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	// Register the global options:
+	flags := rootCmd.PersistentFlags()
+	flags.StringVar(
+		&brokerHost,
+		"host",
+		"localhost",
+		"The IP address or port number of the message broker.",
+	)
+	flags.IntVar(
+		&brokerPort,
+		"port",
+		61613,
+		"The port number of the message server.",
+	)
+	flags.StringVar(
+		&requestsQueue,
+		"requests-queue",
+		"",
+		"The name of the requests queue.",
+	)
+	flags.StringVar(
+		&responsesQueue,
+		"responses-queue",
+		"",
+		"The name of the responses queue.",
+	)
+	flags.StringVar(
+		&userName,
+		"user",
+		"",
+		"The name of the user.",
+	)
+	flags.StringVar(
+		&userPassword,
+		"password",
+		"",
+		"The password of the user.",
+	)
+	flags.BoolVar(
+		&useTLS,
+		"tls",
+		false,
+		"Use TLS.",
+	)
+	flags.BoolVar(
+		&insecureTLS,
+		"insecure",
+		false,
+		"Don't check the server TLS certificate and host name.",
+	)
+
+	// Register the subcommands:
+	rootCmd.AddCommand(requestCmd)
+	rootCmd.AddCommand(respondCmd)
+}
+
+func main() {
+	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
+	// every log messages is prefixed by an error message stating the the flags haven't been
+	// parsed.
+	flag.CommandLine.Parse([]string{})
+
+	// Execute the root command:
+	rootCmd.SetArgs(os.Args[1:])
+	rootCmd.Execute()
+}

--- a/cmd/request-tool/request.go
+++ b/cmd/request-tool/request.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+	"github.com/container-mgmt/messaging-library/pkg/connections/stomp"
+)
+
+var (
+	contentType string
+	messageBody string
+)
+
+var requestCmd = &cobra.Command{
+	Use:   "request",
+	Short: "Sends a request on the requests queue",
+	Long:  "Sends a request on the requests queue.",
+	Run:   runRequest,
+}
+
+var waitResponse chan bool
+
+func init() {
+	flags := requestCmd.Flags()
+	flags.StringVar(
+		&contentType,
+		"content-type",
+		"application/json",
+		"The MIME type of the message body.",
+	)
+	flags.StringVar(
+		&messageBody,
+		"body",
+		"",
+		"The body of the message. If it starts with the @ character then the rest will be "+
+			"interpreted as a file name, and the body of the message will be the content "+
+			"of that file. If this option isn't given then the body will be taken from "+
+			"the standard input.",
+	)
+}
+
+func responseHandler(response client.Message, requestID string) (err error) {
+	if response.Err != nil {
+		err = response.Err
+		glog.Errorf(
+			"Received error from queue: %s",
+			err.Error(),
+		)
+		return
+	}
+
+	glog.Infof(
+		"Received response to request id %s:\n%v",
+		requestID,
+		response.Data,
+	)
+
+	waitResponse <- true
+	return
+}
+
+func runRequest(cmd *cobra.Command, args []string) {
+	var c client.Connection
+	var bodyBytes []byte
+	var err error
+
+	// Check mandatory arguments:
+	if requestsQueue == "" {
+		glog.Errorf("The argument 'requests-queue' is mandatory")
+		return
+	}
+
+	if responsesQueue == "" {
+		glog.Errorf("The argument 'responses-queue' is mandatory")
+		return
+	}
+
+	// Set the clients variables before we can open it.
+	c, err = stomp.NewConnection(&client.ConnectionSpec{
+		// Global options:
+		BrokerHost:   brokerHost,
+		BrokerPort:   brokerPort,
+		UserName:     userName,
+		UserPassword: userPassword,
+		UseTLS:       useTLS,
+		InsecureTLS:  insecureTLS,
+	})
+	if err != nil {
+		glog.Errorf(
+			"Can't connect to message broker at host '%s' and port %d: %s",
+			brokerHost,
+			brokerPort,
+			err.Error(),
+		)
+		return
+	}
+	defer c.Close()
+	glog.Infof(
+		"Connected to message broker at host '%s' and port %d",
+		brokerHost,
+		brokerPort,
+	)
+
+	// Create the Requestor
+	r, err := c.NewRequestor(
+		client.RequestorSpec{
+			RequestsQueue:  requestsQueue,
+			ResponsesQueue: responsesQueue,
+		})
+
+	if err != nil {
+		glog.Errorf(
+			"Failed to create requestor : %s",
+			err.Error(),
+		)
+		return
+	}
+
+	defer r.Close()
+
+	glog.Infof(
+		"Created requestor to '%s'",
+		requestsQueue,
+	)
+
+	// Load the message body:
+	var body string
+	if messageBody == "" {
+		glog.Info("Please insert message body:")
+
+		bodyBytes, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			glog.Errorf(
+				"Can't read message body from standard input: %s",
+				err.Error(),
+			)
+			return
+		}
+		body = string(bodyBytes)
+	} else if messageBody[0] == '@' {
+		messageFile := messageBody[1:]
+		bodyBytes, err = ioutil.ReadFile(messageFile)
+		if err != nil {
+			glog.Errorf(
+				"Can't read message body from file '%s': %s",
+				messageFile,
+				err.Error(),
+			)
+			return
+		}
+		body = string(bodyBytes)
+	} else {
+		body = messageBody
+	}
+
+	// Inform user about the message body.
+	glog.Infof("Message: %s", body)
+
+	// Send a message:
+	// Create a message with data object to send to the message broker,
+	// the data payload must be of type client.MessageData{}.
+	m := client.Message{
+		ContentType: contentType,
+		Data: client.MessageData{
+			"kind": "Request",
+			"body": body,
+		},
+	}
+
+	waitResponse = make(chan bool, 1)
+	r.Send(m, responseHandler)
+
+	// Wait for response.
+	<-waitResponse
+}

--- a/cmd/request-tool/respond.go
+++ b/cmd/request-tool/respond.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+	"github.com/container-mgmt/messaging-library/pkg/connections/stomp"
+)
+
+var respondCmd = &cobra.Command{
+	Use:   "respond",
+	Short: "respond to messages from a queue",
+	Long:  "Respond to messages from a queue.",
+	Run:   runRespond,
+}
+
+func requestHandler(request client.Message) (response client.Message, err error) {
+	if request.Err != nil {
+		err = request.Err
+		glog.Errorf(
+			"Received error from queue: %s",
+			err.Error(),
+		)
+		return
+	}
+
+	glog.Infof(
+		"Received request from destination:\n%v",
+		request.Data,
+	)
+
+	// create an echo response
+	response = client.Message{
+		Data: request.Data,
+	}
+
+	return
+}
+
+func runRespond(cmd *cobra.Command, args []string) {
+	var c client.Connection
+	var err error
+
+	// Check mandatory arguments:
+	if requestsQueue == "" {
+		glog.Errorf("The argument 'requests-queue' is mandatory")
+		return
+	}
+
+	// Set the clients variables before we can open it.
+	c, err = stomp.NewConnection(&client.ConnectionSpec{
+		// Global options:
+		BrokerHost:   brokerHost,
+		BrokerPort:   brokerPort,
+		UserName:     userName,
+		UserPassword: userPassword,
+		UseTLS:       useTLS,
+		InsecureTLS:  insecureTLS,
+	})
+	if err != nil {
+		glog.Errorf(
+			"Can't connect to message broker at host '%s' and port %d: %s",
+			brokerHost,
+			brokerPort,
+			err.Error(),
+		)
+		return
+	}
+	defer c.Close()
+	glog.Infof(
+		"Connected to message broker at host '%s' and port %d",
+		brokerHost,
+		brokerPort,
+	)
+
+	// Create Responder
+	r, err := c.NewResponder(
+		client.ResponderSpec{
+			RequestsQueue: requestsQueue,
+			Callback:      requestHandler,
+		})
+
+	if err != nil {
+		glog.Errorf(
+			"Failed to create responder on '%s': %s",
+			requestsQueue,
+			err.Error(),
+		)
+		return
+	}
+
+	defer r.Close()
+
+	glog.Infof(
+		"Created responder on  '%s' (Press Ctrl-C to exit)",
+		requestsQueue,
+	)
+
+	// wait for requests
+	done := make(chan bool, 1)
+	<-done
+	return
+}

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -93,4 +93,10 @@ type Connection interface {
 
 	// Unsubscribe unsubscribes from a destination
 	Unsubscribe(destination string) error
+
+	// Requestor API
+	NewRequestor(spec RequestorSpec) (r Requestor, err error)
+
+	// Responder API
+	NewResponder(spec ResponderSpec) (r Responder, err error)
 }

--- a/pkg/client/requestor.go
+++ b/pkg/client/requestor.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client contains the types and functions used to communicate with other services using
+// queues and topics.
+package client
+
+// ResponseHandler is called when a response to a request is received
+// m is the response message
+// requestID is the id of the request this message responds
+type ResponseHandler func(response Message, requestID string) error
+
+// RequestorSpec is a helper struct for building requestors.
+type RequestorSpec struct {
+	RequestsQueue  string
+	ResponsesQueue string
+}
+
+// Requestor is a specification of publish/subscribe mechanism
+// It allows sending direct response and supply a callback
+type Requestor interface {
+	Send(request Message, callback ResponseHandler) (requestID string, err error)
+	Close() error
+}

--- a/pkg/client/responder.go
+++ b/pkg/client/responder.go
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client contains the types and functions used to communicate with other services using
+// queues and topics.
+package client
+
+// RequestHandler is called when a new request is received
+// m is the request message
+// requestID is the id of the request
+type RequestHandler func(request Message) (response Message, err error)
+
+// ResponderSpec is a helper struct for building responders.
+type ResponderSpec struct {
+	RequestsQueue string
+	Callback      RequestHandler
+}
+
+// Responder is a request server interface
+type Responder interface {
+	Close() error
+}

--- a/pkg/connections/stomp/requestor.go
+++ b/pkg/connections/stomp/requestor.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package stomp contains the types and functions used to communicate with other services using
+// queues and topics.
+package stomp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+	"github.com/go-stomp/stomp"
+	"github.com/golang/glog"
+	"github.com/segmentio/ksuid"
+)
+
+// Requestor is an implementation of Requestor interface
+// The stomp requestor is a specification of the connection interface
+type Requestor struct {
+	conn           *Connection
+	subscription   *stomp.Subscription
+	requestsQueue  string
+	responsesQueue string
+
+	// mapping between request ID and it's handler
+	pendingRequests map[string]client.ResponseHandler
+}
+
+// NewRequestor creates a new requestor API to submit requests
+func (c *Connection) NewRequestor(spec client.RequestorSpec) (r client.Requestor, err error) {
+
+	// Check if we already subscibe to this destination,
+	// We do not allow for multiple subscriptions for one destination.
+	if _, ok := c.subscriptions[spec.ResponsesQueue]; ok {
+		err = fmt.Errorf("Only one subscription per destination is allowed")
+		return
+	}
+
+	// Subscribe to receive messages:
+	subscription, err := c.connection.Subscribe(spec.ResponsesQueue, stomp.AckAuto)
+	if err != nil {
+		return
+	}
+
+	// add the subscription to the connection
+	c.subscriptions[spec.ResponsesQueue] = subscription
+
+	stompRequestor := &Requestor{
+		conn:            c,
+		requestsQueue:   spec.RequestsQueue,
+		responsesQueue:  spec.ResponsesQueue,
+		subscription:    subscription,
+		pendingRequests: make(map[string]client.ResponseHandler, 0),
+	}
+
+	// wait for responses in the background
+	go stompRequestor.waitForResponses()
+
+	r = stompRequestor
+	return
+}
+
+// Send sends a request to a specific destination
+// request is the message request
+// callback is the handler that will be called when the response is received
+// requestID is returned upon successful send
+func (r *Requestor) Send(request client.Message, callback client.ResponseHandler) (requestID string, err error) {
+
+	// generate request uuid
+	requestID = ksuid.New().String()
+
+	// Add request fields to message
+	request.Data["kind"] = "Request"
+	request.Data["requestID"] = requestID
+	request.Data["respondTo"] = r.responsesQueue
+
+	// send the message
+	// TODO: don't use this function and directly us the stomp API
+	err = r.conn.Publish(request, r.requestsQueue)
+	if err != nil {
+		requestID = ""
+	}
+
+	// keep the handler in the pending requests map
+	r.pendingRequests[requestID] = callback
+
+	return
+}
+
+func (r *Requestor) waitForResponses() {
+	var data client.MessageData
+	for message := range r.subscription.C {
+		// Try to unmarshal the byte array coming from the broker into a
+		// message body of type map[string]interface{}
+		err := json.Unmarshal(message.Body, &data)
+		if err != nil {
+			// log the error and ignore message
+			glog.Warningf(
+				"failed to unmarshall message received from destination %s. Ignoring",
+				r.responsesQueue)
+			continue
+		}
+
+		// Validate message is a response
+		if kind, ok := data["kind"]; !ok || kind.(string) != "Response" {
+			// ignore message
+			glog.Warningf(
+				"Message of non 'Response' kind received on response queue %s. Ignoring",
+				r.responsesQueue)
+			continue
+		}
+
+		// Parse requestId
+		id, ok := data["requestID"]
+		if !ok {
+			// ignore message
+			glog.Warningf(
+				"Response missing 'requestID' field received on response queue %s. Ignoring",
+				r.responsesQueue)
+			continue
+		}
+
+		// Validate requestID
+		callback, ok := r.pendingRequests[id.(string)]
+		if !ok {
+			// ignore message
+			glog.Warningf(
+				"Received response to non existing request id %s. Ignoring",
+				id.(string))
+			continue
+		}
+
+		// call the relevant response handler
+		callback(
+			client.Message{
+				Data: data,
+				Err:  message.Err},
+			id.(string))
+
+		// remove the pending request
+		// TBD - in the future we would like to keep the resuest to allow
+		// a series of responses for a single request.
+		// Currently only one response is supported
+		delete(r.pendingRequests, id.(string))
+	}
+}
+
+// Close closes the Requestor
+func (r *Requestor) Close() (err error) {
+	err = r.conn.Unsubscribe(r.responsesQueue)
+	r.subscription = nil
+	return
+}

--- a/pkg/connections/stomp/responder.go
+++ b/pkg/connections/stomp/responder.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package stomp contains the types and functions used to communicate with other services using
+// queues and topics.
+package stomp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/container-mgmt/messaging-library/pkg/client"
+	"github.com/go-stomp/stomp"
+	"github.com/golang/glog"
+)
+
+// Responder is an implementation of Responder interface
+// The stomp responder is a specification of the connection interface
+type Responder struct {
+	conn          *Connection
+	subscription  *stomp.Subscription
+	requestsQueue string
+	callback      client.RequestHandler
+}
+
+// NewResponder created a new responder with a specific destination
+func (c *Connection) NewResponder(spec client.ResponderSpec) (r client.Responder, err error) {
+	// Check if we already subscibe to this destination,
+	// We do not allow for multiple subscriptions for one destination.
+	if _, ok := c.subscriptions[spec.RequestsQueue]; ok {
+		err = fmt.Errorf("Only one subscription per destination is allowed")
+		return
+	}
+
+	// Subscribe to receive messages:
+	subscription, err := c.connection.Subscribe(spec.RequestsQueue, stomp.AckAuto)
+	if err != nil {
+		return
+	}
+
+	// add the subscription to the connection
+	c.subscriptions[spec.RequestsQueue] = subscription
+
+	stompResponder := &Responder{
+		conn:          c,
+		requestsQueue: spec.RequestsQueue,
+		subscription:  subscription,
+		callback:      spec.Callback,
+	}
+
+	// wait for requests in the background
+	go stompResponder.waitForRequests()
+
+	r = stompResponder
+	return
+}
+
+func (r *Responder) waitForRequests() {
+	var data client.MessageData
+	for message := range r.subscription.C {
+		// Try to unmarshal the byte array coming from the broker into a
+		// message body of type map[string]interface{}
+		err := json.Unmarshal(message.Body, &data)
+		if err != nil {
+			// log the error and ignore message
+			glog.Warningf(
+				"failed to unmarshall message received from destination %s. Ignoring",
+				r.requestsQueue)
+			continue
+		}
+
+		// Validate message is a request
+		if kind, ok := data["kind"]; !ok || kind.(string) != "Request" {
+			// ignore message
+			glog.Warningf(
+				"Message of non 'Request' kind received on requests queue %s. Ignoring",
+				r.requestsQueue)
+			continue
+		}
+
+		// Parse requestId
+		id, ok := data["requestID"]
+		if !ok {
+			// ignore message
+			glog.Warningf(
+				"Request missing 'requestID' field received on requests queue %s. Ignoring",
+				r.requestsQueue)
+			continue
+		}
+
+		// Parse respondTo
+		respondTo, ok := data["respondTo"]
+		if !ok {
+			// ignore message
+			glog.Warningf(
+				"Request missing 'respondTo' field received on requests queue %s. Ignoring",
+				r.requestsQueue)
+			continue
+		}
+
+		// call callback function
+		response, err := r.callback(
+			client.Message{
+				Data: data,
+				Err:  message.Err})
+
+		if err != nil {
+			continue
+		}
+
+		// Add response kind field to message
+		response.Data["kind"] = "Response"
+
+		// Add requestID field to message
+		response.Data["requestID"] = id.(string)
+
+		// publish the response
+		err = r.conn.Publish(response, respondTo.(string))
+		continue
+	}
+}
+
+// Close closes the Responder
+func (r *Responder) Close() (err error) {
+	err = r.conn.Unsubscribe(r.requestsQueue)
+	r.subscription = nil
+	return
+}


### PR DESCRIPTION
Create the Requestor/Responder API and the stomp implementation.
This wraps stomp publish and subscribe mechanism

This is still WIP.
I still need to add usage examples and documentation.

The current implementation only supports a single response per request.
Currently, the Requestor needs to specify the `respondTo` queue when they send the request. In the future we might want to create this queue dynamically upon the request.