### PR TITLE
Add benchmark to makefile, and update tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ lint:
 test:
 	./build.py test
 
+# the bench command should run `go test -bench=. $SOURCE`
+.PHONY: bench
+bench:
+	./build.py bench
+
 .PHONY: fmt
 fmt:
 	./build.py fmt

--- a/build.py
+++ b/build.py
@@ -340,6 +340,14 @@ def test():
     go_tool("go", "test", *pkg_paths)
 
 
+def bench():
+    """
+    Runs the benchmarks.
+    """
+    pkg_paths = ensure_package_paths()
+    go_tool("go", "test", "-bench=.", *pkg_paths)
+
+
 def lint():
     """
     Runs the 'golint' tool on all the source files.
@@ -383,6 +391,10 @@ def main():
     # Create the parser for the 'test' command:
     test_parser = subparsers.add_parser("test")
     test_parser.set_defaults(func=test)
+
+    # Create the parser for the 'bench' command:
+    bench_parser = subparsers.add_parser("bench")
+    bench_parser.set_defaults(func=bench)
 
     # Create the parser for the 'lint' command:
     lint_parser = subparsers.add_parser("lint")


### PR DESCRIPTION
**Description**

a. Add benchmark to makefile.

b. Adjust subscribe/unsubscibe benchmarks, the benchmark requires artimisMQ to run in automatic queue creation mode (Internal STOMP server can't handle this benchmarks).

**Terminal dump**

With 1Kb data payload:
``` bash
13:49 $ make bench
./build.py bench
Calculating project directory
Running command 'go test -bench=. github.com/container-mgmt/messaging-library/pkg/client github.com/container-mgmt/messaging-library/pkg/connections/stomp'
?   	github.com/container-mgmt/messaging-library/pkg/client	[no test files]
Failed to open new STOMP testing server: listen tcp :61613: bind: address already in use
Publish: 42.000000
Received: 42.000000
goos: linux
goarch: amd64
pkg: github.com/container-mgmt/messaging-library/pkg/connections/stomp
BenchmarkOpenAndClose-4             	    2000	    845148 ns/op
BenchmarkPublishAndSubscribe1Kb-4   	   30000	     53930 ns/op
PASS
ok  	github.com/container-mgmt/messaging-library/pkg/connections/stomp	3.999s
```