### PR TITLE
Remove the _Open_ method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,7 +83,9 @@ c, err = stomp.NewConnection(&client.ConnectionSpec{
 	BrokerHost: "localhost",
 	BrokerPort: 1888,
 })
-err = c.Open()
+if err != nil {
+	...
+}
 defer c.Close()
 
 // Set some text to the message.
@@ -146,7 +148,9 @@ c, err = stomp.NewConnection(&client.ConnectionSpec{
 	BrokerHost: "localhost",
 	BrokerPort: 1888,
 })
-err = c.Open()
+if err != nil {
+	...
+}
 defer c.Close()
 
 ...

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -75,17 +75,6 @@ func runReceive(cmd *cobra.Command, args []string) {
 	})
 	if err != nil {
 		glog.Errorf(
-			"Can't create a new connection to host '%s': %s",
-			brokerHost,
-			err.Error(),
-		)
-		return
-	}
-
-	// Connect to the messaging service:
-	err = c.Open()
-	if err != nil {
-		glog.Errorf(
 			"Can't connect to message broker at host '%s' and port %d: %s",
 			brokerHost,
 			brokerPort,
@@ -94,7 +83,7 @@ func runReceive(cmd *cobra.Command, args []string) {
 		return
 	}
 	defer c.Close()
-	glog.Errorf(
+	glog.Infof(
 		"Connected to message broker at host '%s' and port %d",
 		brokerHost,
 		brokerPort,

--- a/cmd/messaging-tool/send.go
+++ b/cmd/messaging-tool/send.go
@@ -88,17 +88,6 @@ func runSend(cmd *cobra.Command, args []string) {
 	})
 	if err != nil {
 		glog.Errorf(
-			"Can't create a new connection to host '%s': %s",
-			brokerHost,
-			err.Error(),
-		)
-		return
-	}
-
-	// Connect to the messaging service:
-	err = c.Open()
-	if err != nil {
-		glog.Errorf(
 			"Can't connect to message broker at host '%s' and port %d: %s",
 			brokerHost,
 			brokerPort,

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -55,9 +55,6 @@ type SubscriptionCallback func(m Message, destination string) error
 // For implementation example see:
 //   https://godoc.org/github.com/container-mgmt/messaging-library/pkg/connections/stomp
 type Connection interface {
-	// Open creates a new connection to the messaging broker.
-	Open() error
-
 	// Close closes the connection, releasing all the resources that it uses. Once closed the
 	// connection can't be reused.
 	Close() error

--- a/pkg/connections/stomp/connection_test.go
+++ b/pkg/connections/stomp/connection_test.go
@@ -97,10 +97,7 @@ func TestNewConnection(t *testing.T) {
 
 func TestOpenAndClose(t *testing.T) {
 	// Create a connection.
-	c, _ := NewConnection(&client.ConnectionSpec{})
-
-	// Try to open and close connection to server.
-	err := c.Open()
+	c, err := NewConnection(&client.ConnectionSpec{})
 	if err != nil {
 		t.Errorf("Fail to open connection: %s", err.Error())
 	}
@@ -112,8 +109,10 @@ func TestPublish(t *testing.T) {
 	destination, _ := DestinationName()
 
 	// Create and open a connection.
-	c, _ := NewConnection(&client.ConnectionSpec{})
-	c.Open()
+	c, err := NewConnection(&client.ConnectionSpec{})
+	if err != nil {
+		t.Errorf("Fail to open connection: %s", err.Error())
+	}
 	defer c.Close()
 
 	// Set a hello world message.
@@ -124,7 +123,7 @@ func TestPublish(t *testing.T) {
 	}
 
 	// Publish our hello message to the "destination name" destination.
-	err := c.Publish(m, destination)
+	err = c.Publish(m, destination)
 	if err != nil {
 		t.Errorf("Fail to publish a message: %s", err.Error())
 	}
@@ -137,8 +136,10 @@ func TestPublishSubscribe(t *testing.T) {
 	// [ When using artimisMQ we can close ]  defer close(messageRecieved)
 
 	// Create and open a connection.
-	c, _ := NewConnection(&client.ConnectionSpec{})
-	c.Open()
+	c, err := NewConnection(&client.ConnectionSpec{})
+	if err != nil {
+		t.Errorf("Fail to open connection: %s", err.Error())
+	}
 	defer c.Close()
 
 	// Set a hello world message.
@@ -170,8 +171,10 @@ func TestPublishSubscribe(t *testing.T) {
 
 func BenchmarkOpenAndClose(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		c, _ := NewConnection(&client.ConnectionSpec{})
-		c.Open()
+		c, err := NewConnection(&client.ConnectionSpec{})
+		if err != nil {
+			b.Errorf("Fail to open connection: %s", err.Error())
+		}
 		c.Close()
 	}
 }
@@ -188,8 +191,10 @@ func BenchmarkPublishAndSubscribe1Kb(b *testing.B) {
 	defer close(messageRecieved)
 
 	// Create and open a connection.
-	c, _ := NewConnection(&client.ConnectionSpec{})
-	c.Open()
+	c, err := NewConnection(&client.ConnectionSpec{})
+	if err != nil {
+		b.Errorf("Fail to open connection: %s", err.Error())
+	}
 	defer c.Close()
 
 	// Subscribe to the "destination name" destination.


### PR DESCRIPTION
The _Open_ method of the connection type isn't needed, because a connection isn't useful if it isn't open. This patch removes the method, so that the connection will be inmediately open upon return from the `NewConnection` method.