### PR TITLE
Install ActiveMQ Artemis in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,22 @@ go:
 go_import_path: github.com/container-mgmt/messaging-library
 
 install:
+
+# Install required Go tools:
 - go get github.com/golang/dep/cmd/dep
 - go get golang.org/x/lint/golint
 - go get github.com/client9/misspell/cmd/misspell
+
+# Install ActiveMQ Artemis and create an instance:
+- wget --output-document artemis.tar.gz "https://www.apache.org/dyn/closer.cgi?filename=activemq/activemq-artemis/2.6.1/apache-artemis-2.6.1-bin.tar.gz&action=download"
+- echo "b56d27107c6b362eb31a85d2a4720134b3142c5f2ed61d44a08eda57fc3764d6 artemis.tar.gz" | sha256sum --check
+- mkdir --parents $HOME/artemis/home
+- tar --strip-components=1 --directory=$HOME/artemis/home --extract --file=artemis.tar.gz
+- $HOME/artemis/home/bin/artemis create --home=$HOME/artemis/home --host="localhost" --silent $HOME/artemis/instance
+- $HOME/artemis/instance/bin/artemis-service start
 
 script:
 - make build test lint
 - make binaries
 - misspell -error cmd/** pkg/** README.adoc
+- make bench


### PR DESCRIPTION
This patch changes the `.travis.yml` file so that it creates an instance of ActiveMQ Artemis that can then be used to run the tests and the benchmarks.