### PR TITLE
Add -set_exit_status flag to golint

### DIFF
--- a/build.py
+++ b/build.py
@@ -353,7 +353,7 @@ def lint():
     Runs the 'golint' tool on all the source files.
     """
     pkg_paths = ensure_package_paths()
-    go_tool("golint", "-min_confidence", "0.9", *pkg_paths)
+    go_tool("golint", "-min_confidence", "0.9", "-set_exit_status", *pkg_paths)
 
 
 def fmt():

--- a/pkg/connections/stomp/connection_test.go
+++ b/pkg/connections/stomp/connection_test.go
@@ -23,8 +23,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"time"
 	"testing"
+	"time"
 
 	"github.com/go-stomp/stomp/server"
 
@@ -196,17 +196,17 @@ func TestPublishSubscribeRunTime(t *testing.T) {
 	start := time.Now()
 
 	// Set a 1Kb message 1000 times.
-	for n:= 0; n < runTimes; n++ {
+	for n := 0; n < runTimes; n++ {
 		m = client.Message{
 			Data: client.MessageData{
-				"value": n,
+				"value":        n,
 				"bigByteArray": thousandBytes,
 			},
 		}
 		c.Publish(m, destination)
 	}
 
-	for n:= 0; n < runTimes; n++ {
+	for n := 0; n < runTimes; n++ {
 		r := <-messageRecieved
 		if int(r) != n {
 			t.Errorf("Received %f expected %d", r, n)
@@ -215,7 +215,7 @@ func TestPublishSubscribeRunTime(t *testing.T) {
 
 	// Check time elapsed
 	elapsed := time.Since(start)
-	if (elapsed > runMaxTime) {
+	if elapsed > runMaxTime {
 		t.Errorf("Test took %s [max is %s]", elapsed, runMaxTime)
 	}
 }


### PR DESCRIPTION
**Description**

Add `-set_exit_status` flag to golint, currently the travis lint command will exit without error even if erros found, the `-set_exit_status` send a none valid exit status on linting errors.