### PR TITLE
Add a travis test for fmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ install:
 - $HOME/artemis/instance/bin/artemis-service start
 
 script:
-- make build test lint
+- if [ $(gofmt -s -l ./pkg/ ./cmd/ | wc -l) -eq 0 ]; then true; else false; fi;
+- make lint
+- make build test
 - make binaries
 - misspell -error cmd/** pkg/** README.adoc
 - make bench

--- a/build.py
+++ b/build.py
@@ -333,12 +333,8 @@ def lint():
     """
     Runs the 'golint' tool on all the source files.
     """
-    go_tool(
-        "golint",
-        "-min_confidence", "0.9",
-        "-set_exit_status",
-        "./pkg/...",
-        "./cmd/...")
+    go_tool("golint", "-set_exit_status", "./pkg/...")
+    go_tool("golint", "-set_exit_status", "./cmd/...")
 
 
 def fmt():


### PR DESCRIPTION
**Description**

a. Add a travis test for go fmt.
b. fix a bug in lint test, the golint comand can't take two dirs, dividing to two commands.


