### PR TITLE
Avoid nested exceptions due to cache in `build.py`

### DIFF
--- a/build.py
+++ b/build.py
@@ -64,9 +64,9 @@ def cache(function):
     cache = dict()
 
     def helper(*key):
-        try:
+        if key in cache:
             value = cache[key]
-        except KeyError:
+        else:
             value = function(*key)
             cache[key] = value
         return value


### PR DESCRIPTION
Currently when the build fails in a function whose result is cached we generate a nested exception message. For example, if the `docker` command doesn't exist the error message is like this:

```
./build.py build
Calculating project directory
Running command 'go install ...'
pkg/client/message.go:26:1: syntax error: non-declaration statement outside function body
Traceback (most recent call last):
  File "./build.py", line 68, in helper
    value = cache[key]
KeyError: ()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./build.py", line 386, in <module>
    main()
  File "./build.py", line 379, in main
    argv.func()
  File "./build.py", line 284, in build
    ensure_packages()
  File "./build.py", line 70, in helper
    value = function(*key)
  File "./build.py", line 242, in ensure_packages
    go_tool("go", "install", *pkg_paths)
  File "./build.py", line 106, in go_tool
    code=result,
Exception: Command 'go install ...' failed with exit code 2
```

That error message is confusing. To make it less confusing this patch
changes the `cache` function so that it will not generate these nested
exception messages. The message will be now like this:

```
./build.py build
Calculating project directory
Running command 'go install ...'
pkg/client/message.go:26:1: syntax error: non-declaration statement outside function body
Traceback (most recent call last):
  File "./build.py", line 386, in <module>
    main()
  File "./build.py", line 379, in main
    argv.func()
  File "./build.py", line 284, in build
    ensure_packages()
  File "./build.py", line 70, in helper
    value = function(*key)
  File "./build.py", line 242, in ensure_packages
    go_tool("go", "install", *pkg_paths)
  File "./build.py", line 106, in go_tool
    code=result,
Exception: Command 'go install ...' failed with exit code 2
```