### PR TITLE
Remove obsolete signal handling in receive example

### DIFF
--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -34,12 +34,11 @@ var receiveCmd = &cobra.Command{
 func callback(message client.Message, destination string) (err error) {
 	if message.Err != nil {
 		err = message.Err
-		glog.Errorf(
+		glog.Fatalf(
 			"Received error from destination '%s': %s",
 			destinationName,
 			err.Error(),
 		)
-		return
 	}
 
 	glog.Infof(

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -17,9 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"os"
-	"os/signal"
-
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
@@ -106,10 +103,13 @@ func runReceive(cmd *cobra.Command, args []string) {
 		destinationName,
 	)
 
-	// Wait for Ctrl+C.
-	waitCtrlC := make(chan os.Signal, 1)
-	signal.Notify(waitCtrlC, os.Interrupt)
-	<-waitCtrlC
+	// wait for messages
+	done := make(chan bool, 1)
+	go func() {
+		for {
+		}
+	}()
+	<-done
 
 	return
 }

--- a/cmd/messaging-tool/receive.go
+++ b/cmd/messaging-tool/receive.go
@@ -105,10 +105,6 @@ func runReceive(cmd *cobra.Command, args []string) {
 
 	// wait for messages
 	done := make(chan bool, 1)
-	go func() {
-		for {
-		}
-	}()
 	<-done
 
 	return


### PR DESCRIPTION
Fixing https://github.com/container-mgmt/messaging-library/issues/72
Remove the interrupt handling code, since it is already handled by cobra pkg